### PR TITLE
残業貯金から日付による計算除外機能の追加 #1

### DIFF
--- a/content.js
+++ b/content.js
@@ -273,11 +273,13 @@ async function getWorkTime(){
   const arrayOfWorkTime = []; // 労働時間の配列
 
   // TEST: 無視する日付
-  const testIgnoreDateArray = [
-    '10/02（水）',
-    '10/03（木）',
-    '10/04（金）',
-  ];
+  // const testIgnoreDateArray = [
+  //   '10/02（水）',
+  //   '10/03（木）',
+  //   '10/04（金）',
+  // ];
+  const ignoreDateTextArray = await chrome.storage.sync.get(['ignoreWorkingTimeDates']);
+  console.log(`ignoreDateArray: ${ignoreDateTextArray}`)
 
   // 日付レコードそれぞれに対して、日付と労働合計（1日分）を取得し、合計する
   TableRecordByDateArray.forEach((TableRecordByDate) => {
@@ -288,8 +290,8 @@ async function getWorkTime(){
     // 除外指定された日付は無視する
     ignoreCalculate = false;
 
-    testIgnoreDateArray.forEach((testIgnoreDate) => {
-      if (dateText === testIgnoreDate) {
+    ignoreDateTextArray.forEach((ignoreDateText) => {
+      if (dateText === ignoreDateText) {
         ignoreCalculate = true;
         return;
       }

--- a/content.js
+++ b/content.js
@@ -278,25 +278,37 @@ async function getWorkTime(){
   //   '10/03（木）',
   //   '10/04（金）',
   // ];
-  const ignoreDateTextArray = await chrome.storage.sync.get(['ignoreWorkingTimeDates']);
-  console.log(`ignoreDateArray: ${ignoreDateTextArray}`)
+  const value = await chrome.storage.sync.get(['ignoreWorkingTimeDates']);
+
+  let ignoreDateText;
+
+  // nullだった場合、空文字列を代入する
+  if (value == null) {
+    ignoreDateText = ''
+  } else {
+    ignoreDateText = value.ignoreWorkingTimeDates;
+  }
+
+  const NotCalForWorkTimeDateTexts = ignoreDateText ? ignoreDateText.split(',') : [];
 
   // 日付レコードそれぞれに対して、日付と労働合計（1日分）を取得し、合計する
   TableRecordByDateArray.forEach((TableRecordByDate) => {
 
     const dateTd = TableRecordByDate.getDateTd();
-    const dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白を取り除く
+    const dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白が含まれているため、取り除く
 
-    // 除外指定された日付は無視する
-    ignoreCalculate = false;
+    // FIXME: rename
+    isContinueDate = false;
 
-    ignoreDateTextArray.forEach((ignoreDateText) => {
-      if (dateText === ignoreDateText) {
-        ignoreCalculate = true;
+    NotCalForWorkTimeDateTexts.forEach((NotCalForWorkTimeDateText) => {
+      if (dateText === NotCalForWorkTimeDateText) {
+        isContinueDate = true;
         return;
       }
     })
-    if (ignoreCalculate === true) {
+
+    // 除外指定された日付は無視する
+    if (isContinueDate === true) {
       return;
     }
 

--- a/content.js
+++ b/content.js
@@ -272,35 +272,29 @@ async function getWorkTime(){
   // 労働時間を取得
   const arrayOfWorkTime = []; // 労働時間の配列
 
-  // // 労働時間ヘッダーのクラス名から労働時間の値の配列を取得している
-  // const workTimeElements = document.querySelectorAll(`.htBlock-adjastableTableF tbody td.${workTimeClass} > p`);
-  // if(workTimeElements.length > 0){
-  //   workTimeElements.forEach((workTimeElement) => {
-  //     const workTimeText = workTimeElement.textContent;
-
-  //     // 労働時間の値が書き込まれていなかったら（明日に勤怠打刻はない）、労働時間をリストに挿入するのやめる
-  //     try{
-  //       let workTimeTextString = Time.fromString(workTimeText);
-  //       // console.log(`workTimeTextString: ${workTimeTextString}`);
-  //       arrayOfWorkTime.push(workTimeTextString);
-  //     } catch (e) {
-  //       return;
-  //     }
-  //   });
-  // }
-
   // TEST: 無視する日付
-  const testIgnoreDate = '10/03（木）';
+  const testIgnoreDateArray = [
+    '10/02（水）',
+    '10/03（木）',
+    '10/04（金）',
+  ];
 
   // 日付レコードそれぞれに対して、日付と労働合計（1日分）を取得し、合計する
   TableRecordByDateArray.forEach((TableRecordByDate) => {
+
     const dateTd = TableRecordByDate.getDateTd();
     const dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白を取り除く
 
-    console.log(`testIgnoreDate: ${testIgnoreDate}, dateText: ${dateText}`);
     // 除外指定された日付は無視する
-    if (dateText === testIgnoreDate) {
-      console.log("ignore!");
+    ignoreCalculate = false;
+
+    testIgnoreDateArray.forEach((testIgnoreDate) => {
+      if (dateText === testIgnoreDate) {
+        ignoreCalculate = true;
+        return;
+      }
+    })
+    if (ignoreCalculate === true) {
       return;
     }
 
@@ -311,7 +305,7 @@ async function getWorkTime(){
     try {
       const workTimeText = Time.fromString(workTimeRawText);
       arrayOfWorkTime.push(workTimeText);
-      console.log(`dateText: ${dateText}, workTimeText: ${workTimeText}`);
+      // console.log(`dateText: ${dateText}, workTimeText: ${workTimeText}`);
     } catch (e) {
       return;
     }

--- a/content.js
+++ b/content.js
@@ -150,6 +150,8 @@ async function getOverWorkTime(regularWorkTimePerDay = new Time(0)){
   const workTimes = await getWorkTime();
   if(workTimes.length > 0){
     workTimes.forEach((workTime) => {
+      console.log(`実際の労働時間 - 基本労働時間 = 残業貯金`)
+      console.log(`${workTime} - ${regularWorkTimePerDay} = ${workTime.minus(regularWorkTimePerDay)}`)
       amountOfOvertime = amountOfOvertime.plus(workTime.minus(regularWorkTimePerDay));
     });
   }
@@ -288,6 +290,7 @@ async function getWorkTime(){
   } else {
     ignoreDateText = value.ignoreWorkingTimeDates;
   }
+  console.log(`ignoreDateText: ${ignoreDateText}`);
 
   const NotCalForWorkTimeDateTexts = ignoreDateText ? ignoreDateText.split(',') : [];
 
@@ -295,20 +298,24 @@ async function getWorkTime(){
   TableRecordByDateArray.forEach((TableRecordByDate) => {
 
     const dateTd = TableRecordByDate.getDateTd();
-    const dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白が含まれているため、取り除く
+    let dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白が含まれているため、取り除く
+    dateText = dateText.substring(0, dateText.indexOf('（'));  // 曜日を乗り除く  (ex. 10/10（木） -> 10/10)
 
     // FIXME: rename
     isContinueDate = false;
 
     NotCalForWorkTimeDateTexts.forEach((NotCalForWorkTimeDateText) => {
+      console.log(`dateText: ${dateText}, NotCalForWorkTimeDateText: ${NotCalForWorkTimeDateText}`);
       if (dateText === NotCalForWorkTimeDateText) {
         isContinueDate = true;
+        console.log("isContinue!");
         return;
       }
     })
 
     // 除外指定された日付は無視する
     if (isContinueDate === true) {
+      console.log(`ignore: ${dateText}`);
       return;
     }
 

--- a/content.js
+++ b/content.js
@@ -219,7 +219,6 @@ class TableRecordByDate {
   }
 
   getTdFromClassName(className) {
-    console.log(`TEST: td.${className}`);
     return this.trElement.querySelector(`td.${className}`);
   }
 }
@@ -264,6 +263,7 @@ async function getWorkTime(){
   // MEMO: 日付ヘッダーを見つける
   // const dateHeader = document.querySelector('.htBlock-adjastableTableF thead th.specific_date p');
 
+  // すべての日付レコードをTableRecordByDateへ変換する
   const TableRecordByDateArray = Array.from(
     document.querySelectorAll('.htBlock-adjastableTableF tbody tr'),
     td => new TableRecordByDate(td)
@@ -289,10 +289,20 @@ async function getWorkTime(){
   //   });
   // }
 
-  // すべての日付を書き出す処理
+  // TEST: 無視する日付
+  const testIgnoreDate = '10/03（木）';
+
+  // 日付レコードそれぞれに対して、日付と労働合計（1日分）を取得し、合計する
   TableRecordByDateArray.forEach((TableRecordByDate) => {
     const dateTd = TableRecordByDate.getDateTd();
-    const dateText = dateTd.querySelector('p').textContent;
+    const dateText = dateTd.querySelector('p').textContent.trim();  // 改行と空白を取り除く
+
+    console.log(`testIgnoreDate: ${testIgnoreDate}, dateText: ${dateText}`);
+    // 除外指定された日付は無視する
+    if (dateText === testIgnoreDate) {
+      console.log("ignore!");
+      return;
+    }
 
     const workTimeTd = TableRecordByDate.getTdFromClassName(workTimeClass);
     const workTimeRawText = workTimeTd.querySelector('p').textContent;
@@ -301,11 +311,10 @@ async function getWorkTime(){
     try {
       const workTimeText = Time.fromString(workTimeRawText);
       arrayOfWorkTime.push(workTimeText);
+      console.log(`dateText: ${dateText}, workTimeText: ${workTimeText}`);
     } catch (e) {
       return;
     }
-
-    // console.log(`dateText: ${dateText}, workTimeText: ${workTimeText}`);
   })
 
   return arrayOfWorkTime;

--- a/popup.html
+++ b/popup.html
@@ -17,8 +17,8 @@
         <input type="text" id="setWorkingTimeTitle" placeholder="例：所定時間, 実働時間">
     </div>
     <div class="settings">
-        <label for="setIgnoreWorkingTimeDates">残業貯金の計算から除外する日付（コンマで複数の日付）</label>
-        <input type="text" id="setIgnoreWorkingTimeDates" placeholder="例：10/01,10/03">
+        <label for="setNotCalDatesForWorkingTime">残業貯金の計算から除外する日付（コンマで複数の日付）</label>
+        <input type="text" id="setNotCalDatesForWorkingTime" placeholder="例：10/01,10/03">
     </div>
     <div>
         <button id="changeSettings">設定変更</button>

--- a/popup.html
+++ b/popup.html
@@ -16,6 +16,10 @@
         <label for="setWorkingTimePerDay">1日の実際の労働時間の列ラベル<br />（デフォルト：労働合計）</label>
         <input type="text" id="setWorkingTimeTitle" placeholder="例：所定時間, 実働時間">
     </div>
+    <div class="settings">
+        <label for="setIgnoreWorkingTimeDates">残業貯金の計算から除外する日付（コンマで複数の日付）</label>
+        <input type="text" id="setIgnoreWorkingTimeDates" placeholder="例：10/01,10/03">
+    </div>
     <div>
         <button id="changeSettings">設定変更</button>
     </div>

--- a/popup.js
+++ b/popup.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
   const regularWorkingTimeInput = document.getElementById('setWorkingTimePerDay');
   const workingTimeTitleInput = document.getElementById('setWorkingTimeTitle');
+  const ignoreWorkingTimeDatesInput = document.getElementById('setIgnoreWorkingTimeDates');
 
   // 保存された値を取得して入力フィールドに設定
   chrome.storage.sync.get(['regularWorkTime'], function(result) {
@@ -11,6 +12,11 @@ document.addEventListener('DOMContentLoaded', function() {
   chrome.storage.sync.get(['WorkTimeTitle'], function(result) {
     if (result.WorkTimeTitle) {
         workingTimeTitleInput.value = result.WorkTimeTitle;
+    }
+  });
+  chrome.storage.sync.get(['ignoreWorkingTimeDates'], function(result) {
+    if (result.ignoreWorkingTimeDates) {
+        ignoreWorkingTimeDatesInput.value = result.ignoreWorkingTimeDates;
     }
   });
 
@@ -30,5 +36,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     chrome.storage.sync.set({ regularWorkTime: regularWorkingTimeInput.value });
     chrome.storage.sync.set({ WorkTimeTitle: workingTimeTitleInput.value });
+    chrome.storage.sync.set({ ignoreWorkingTimeDates: ignoreWorkingTimeDatesInput.value });
   });
 });

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
   const regularWorkingTimeInput = document.getElementById('setWorkingTimePerDay');
   const workingTimeTitleInput = document.getElementById('setWorkingTimeTitle');
-  const ignoreWorkingTimeDatesInput = document.getElementById('setIgnoreWorkingTimeDates');
+  const NotCalDatesForWorkingTimeInput = document.getElementById('setNotCalDatesForWorkingTime');
 
   // 保存された値を取得して入力フィールドに設定
   chrome.storage.sync.get(['regularWorkTime'], function(result) {
@@ -14,9 +14,9 @@ document.addEventListener('DOMContentLoaded', function() {
         workingTimeTitleInput.value = result.WorkTimeTitle;
     }
   });
-  chrome.storage.sync.get(['ignoreWorkingTimeDates'], function(result) {
-    if (result.ignoreWorkingTimeDates) {
-        ignoreWorkingTimeDatesInput.value = result.ignoreWorkingTimeDates;
+  chrome.storage.sync.get(['notCalDatesForWorkingTime'], function(result) {
+    if (result.notCalDatesForWorkingTime) {
+        NotCalDatesForWorkingTimeInput.value = result.notCalDatesForWorkingTime;
     }
   });
 
@@ -36,6 +36,6 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     chrome.storage.sync.set({ regularWorkTime: regularWorkingTimeInput.value });
     chrome.storage.sync.set({ WorkTimeTitle: workingTimeTitleInput.value });
-    chrome.storage.sync.set({ ignoreWorkingTimeDates: ignoreWorkingTimeDatesInput.value });
+    chrome.storage.sync.set({ notCalDatesForWorkingTime: NotCalDatesForWorkingTimeInput.value });
   });
 });


### PR DESCRIPTION
## 概要
残業貯金として計算**しない**日付を指定できるようにしました
ポップアップから`10/01,10/03`のように入力することで指定が可能です

## 実装したこと
- 労働日数などと同様に、ポップアップに日付を書き込みストレージへ保存する仕組みを実装
- 日別のテーブルレコードを扱うクラスである`TableRecordByDate`クラスの実装
  - 日別のテーブルレコードから労働合計や日付などの値を取得する関数を集約
- `労働合計`を合計する処理にて、指定された日付と一致した場合、計算しない処理を実装

## 変更結果
1. 日付を何もしていない状態では、残業貯金が`1.04`となっています
![スクリーンショット 2024-10-11 1 13 56のコピー](https://github.com/user-attachments/assets/ddf00677-6b19-45e7-b807-ac89ab6c70bd)

2. `10/04,10/09`の2日間を除外する日付として指定し、残業貯金が`2.15`に変化。除外指定が働いたことが確認できました。
![スクリーンショット 2024-10-11 1 09 44](https://github.com/user-attachments/assets/635fa71b-064b-49a9-b259-3be091fa2731)

## 実装において補足したいこと
### 残業貯金を計算するこちらのコードブロックについて
https://github.com/nakashima-takeo/KoT-plus/blob/49e9d4dfe024f7001e55b0c69fa78e7c0e4843fa/content.js#L238-L252

日付の取得と同様に、労働合計を取得する処理も`TableRecordByDate`クラスへ集約したため、コード全体を書きかえました。

### コード全体のスタイルについて
クラス・関数の場所・変数に使用する名前は、既存のコードを見ながら合わせました（つもり）

### ストレージへの保存処理について
Chrome APIについて理解が足りていなく、雰囲気で実装したのでバグがあるかもしれません
（今のところ問題なく動作しているように見えます）

## 実装していないこと
- 日付のフォーマットが正しくない場合にユーザーへ伝える処理

## レビューして欲しいところ
- 実装にバグ等の問題がないか
- （プルリクエストやコミットの文章など）

## 注意事項
特にありません